### PR TITLE
add support for FreeBSD, pet puppet-lint

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -178,8 +178,6 @@ tarsnap::periodic { 'etc':
 While it is possible to configure tarsnap on a per-user basis, tarsnap::config
 currently is a class. If you think it's useful to change that, please contribute!
 
-`tarsnap::periodic` assumes GNU coreutils.
-
 ## Development
 
 Since your module is awesome, other users will want to play with it. Let them know what the ground rules for contributing are.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,15 +6,15 @@ class tarsnap::config {
 
   file { $::tarsnap::cachedir:
     ensure => directory,
-    owner  => 'root',
-    group  => 'root',
+    owner  => $::tarsnap::user,
+    group  => $::tarsnap::group,
     mode   => '0700',
   }
 
   file { $::tarsnap::configfile:
     ensure  => file,
-    owner   => 'root',
-    group   => 'root',
+    owner   => $::tarsnap::user,
+    group   => $::tarsnap::group,
     mode    => '0644',
     content => template("${module_name}/tarsnap.conf.erb"),
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,10 +5,12 @@
 # === Parameters
 #
 # [*package_name*]
-#   Name of tarsnap package. If tarsnap is installed by other means, set this to `undef` (Default: `tarsnap`)
+#   Name of tarsnap package. If tarsnap is installed by other means, set this to
+#   `undef` (Default: `tarsnap`)
 #
 # [*package_ensure*]
-#   Ensure tarsnap package is in this version, `absent`, `present` or `latest`. (Default: `present`)
+#   Ensure tarsnap package is in this version, `absent`, `present` or `latest`.
+#   (Default: `present`)
 #
 # [*path*]
 #   Path to tarsnap. (Default: `/usr/bin/tarsnap`)
@@ -23,7 +25,8 @@
 #   Path to tarsnap's configuration file. (Default: `/etc/tarsnap.conf`)
 #
 # [*cachedir*]
-#   Path to tarsnap's cachedir. This directory will be created by puppet. (Default: `/var/backups/tarsnap`)
+#   Path to tarsnap's cachedir. This directory will be created by puppet.
+#   (Default: `/var/backups/tarsnap`)
 #
 # [*keyfile*]
 #   Path to tarsnap's keyfile for this machine. (Default: `/root/tarsnap.key`)
@@ -41,19 +44,22 @@
 #   Use multiple TCP connections when writing archives. (Default: `undef`)
 #
 class tarsnap (
-  $package_name          = 'tarsnap',
-  $package_ensure        = 'present',
-  $path                  = '/usr/bin/tarsnap',
-  $archive_path          = '/usr/local/bin/tarsnap-archive',
-  $rotate_path           = '/usr/local/bin/tarsnap-rotate',
-  $configfile            = '/etc/tarsnap.conf',
-  $cachedir              = '/var/backups/tarsnap',
-  $keyfile               = '/root/tarsnap.key',
-  $nodump                = true,
-  $print_stats           = true,
-  $checkpoint_bytes      = '1G',
-  $aggressive_networking = undef,
-) {
+  $package_name          = $::tarsnap::params::package_name,
+  $package_ensure        = $::tarsnap::params::package_ensure,
+  $path                  = $::tarsnap::params::path,
+  $archive_path          = $::tarsnap::params::archive_path,
+  $rotate_path           = $::tarsnap::params::rotate_path,
+  $configfile            = $::tarsnap::params::configfile,
+  $cachedir              = $::tarsnap::params::cachedir,
+  $keyfile               = $::tarsnap::params::keyfile,
+  $nodump                = $::tarsnap::params::nodump,
+  $print_stats           = $::tarsnap::params::print_stats,
+  $checkpoint_bytes      = $::tarsnap::params::checkpoint_bytes,
+  $aggressive_networking = $::tarsnap::params::aggressive_networking,
+  $user                  = $::tarsnap::params::user,
+  $group                 = $::tarsnap::params::group,
+) inherits ::tarsnap::params {
+
   validate_absolute_path($path)
   validate_absolute_path($archive_path)
   validate_absolute_path($rotate_path)
@@ -63,10 +69,11 @@ class tarsnap (
 
   validate_bool($nodump)
   validate_bool($print_stats)
+
   if $aggressive_networking {
     validate_bool($print_stats)
   }
 
-  contain ::tarsnap::install
-  contain ::tarsnap::config
+  class { '::tarsnap::install': } ~>
+  class { '::tarsnap::config': }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,41 @@
+# == Class: tarsnap::params
+#
+# params class providing defaults for each supported operating system
+#
+class tarsnap::params {
+
+  $package_ensure        = 'present'
+  $keyfile               = '/root/tarsnap.key'
+  $nodump                = true
+  $print_stats           = true
+  $checkpoint_bytes      = '1G'
+  $aggressive_networking = undef
+
+  case $::kernel {
+    'Linux': {
+      $package_name = 'tarsnap'
+      $prefix       = '/usr/local'
+      $path         = '/usr/bin/tarsnap'
+      $archive_path = "${prefix}/bin/tarsnap-archive"
+      $rotate_path  = "${prefix}/bin/tarsnap-rotate"
+      $configfile   = '/etc/tarsnap.conf'
+      $cachedir     = '/var/backups/tarsnap'
+      $user         = 'root'
+      $group        = 'root'
+    }
+    'FreeBSD': {
+      $package_name = 'tarsnap'
+      $prefix       = '/usr/local'
+      $path         = "${prefix}/bin/tarsnap"
+      $archive_path = "${prefix}/bin/tarsnap-archive"
+      $rotate_path  = "${prefix}/bin/tarsnap-rotate"
+      $configfile   = "${prefix}/etc/tarsnap.conf"
+      $cachedir     = "${prefix}/tarsnap-cache"
+      $user         = 'root'
+      $group        = 'wheel'
+    }
+    default: {
+      fail("Unsupported operating system: ${::kernel}")
+    }
+  }
+}

--- a/manifests/periodic.pp
+++ b/manifests/periodic.pp
@@ -14,13 +14,16 @@
 #   Array of dirs to backup (Default: `[]`)
 #
 # [*keep*]
-#   How many archives to keep. If this is set to `undef` no archives will be deleted. (Default: `30`)
+#   How many archives to keep. If this is set to `undef` no archives will be
+#   deleted. (Default: `30`)
 #
 # [*hour*]
-#   Hour when to run. (Default: `fqdn_rand(24, $title)`, i.e.: between 0:xx and 23:xx)
+#   Hour when to run. (Default: `fqdn_rand(24, $title)`, i.e.: between 0:xx
+#   and 23:xx)
 #
 # [*minute*]
-#   Minute when to run. (Default: `fqdn_rand(60, $title)`, i.e.: between xx:00 and xx:59)
+#   Minute when to run. (Default: `fqdn_rand(60, $title)`, i.e.: between xx:00
+#   and xx:59)
 #
 # [*offset*]
 #   Offset (in hours) when to run the cleanup job. (Default: `1`)
@@ -41,7 +44,7 @@ define tarsnap::periodic (
   cron { "tarsnap-${title}-create":
     ensure  => $ensure,
     command => "${::tarsnap::archive_path} ${title} ${dir_string}",
-    user    => 'root',
+    user    => $::tarsnap::user,
     hour    => $hour,
     minute  => $minute,
   }
@@ -55,7 +58,7 @@ define tarsnap::periodic (
     cron { "tarsnap-${title}-keep-${keep}":
       ensure  => $ensure,
       command => "${::tarsnap::rotate_path} ${title} ${keep}",
-      user    => 'root',
+      user    => $::tarsnap::user,
       hour    => $off_hour,
       minute  => $minute,
     }

--- a/templates/tarsnap-archive.erb
+++ b/templates/tarsnap-archive.erb
@@ -3,4 +3,4 @@
 title="$1"
 shift
 
-<%= @path %> --quiet -c -f $title.$(date +%Y%m%d%H%M) $@
+<%= scope.lookupvar("tarsnap::path") %> --quiet -c -f $title.$(date +%Y%m%d%H%M) $@

--- a/templates/tarsnap-rotate.erb
+++ b/templates/tarsnap-rotate.erb
@@ -6,9 +6,15 @@ shift
 keep="$1"
 shift
 
-<%= @path %> --list-archives \
+<%- # handle potential absence of GNU coreutils -%>
+<%- if @kernel == "Linux" -%>
+<%-   cmd_keep  = 'tail -n +${keep}' -%>
+<%- else -%>
+<%-   cmd_keep  = 'sed "1,${keep}d"' -%>
+<%- end -%>
+<%= scope.lookupvar("tarsnap::path") %> --list-archives \
   | grep ${title}. \
   | sort -rn \
-  | tail -n +${keep} \
-  | xargs -rn1 <%= @path %> -d -f
+  | <%= cmd_keep %> \
+  | xargs -rn1 <%= scope.lookupvar("tarsnap::path") %> -d -f
 

--- a/templates/tarsnap.conf.erb
+++ b/templates/tarsnap.conf.erb
@@ -1,19 +1,19 @@
 ### Recommended options
 
 # Tarsnap cache directory
-cachedir <%= @cachedir %>
+cachedir <%= scope.lookupvar("tarsnap::cachedir") %>
 
 # Tarsnap key file
-keyfile <%= @keyfile %>
+keyfile <%= scope.lookupvar("tarsnap::keyfile") %>
 
 # Don't archive files which have the nodump flag set
-<%- unless @nodump -%>no-<%- end -%>nodump
+<%- unless scope.lookupvar("tarsnap::nodump") -%>no-<%- end -%>nodump
 
 # Print statistics when creating or deleting archives
-<%- unless @print_stats -%>no-<%- end -%>print-stats
+<%- unless scope.lookupvar("tarsnap::print_stats") -%>no-<%- end -%>print-stats
 
 # Create a checkpoint once per GB of uploaded data.
-checkpoint-bytes <%= @checkpoint_bytes %>
+checkpoint-bytes <%= scope.lookupvar("tarsnap::checkpoint_bytes") %>
 
 ### Other options, not applicable to most systems
 
@@ -21,9 +21,9 @@ checkpoint-bytes <%= @checkpoint_bytes %>
 # writing archives.  Use of this option is recommended only in
 # cases where TCP congestion control is known to be the limiting
 # factor in upload performance.
-<%- if @aggresssive_networking.nil? -%>
+<%- if scope.lookupvar("tarsnap::aggresssive_networking").nil? -%>
 #aggressive-networking
-<%- elsif !@aggressive_networking -%>
+<%- elsif !scope.lookupvar("tarsnap::aggressive_networking") -%>
 no-aggressive-networking
 <%- else -%>
 aggressive-networking


### PR DESCRIPTION
This adds support for FreeBSD and handles the following differences:

* group `root` is named `wheel` on FreeBSD
* additional software is installed under `/usr/local`
* cachedir is `/usr/local/tarsnap-cache`
* `tarsnap-rotate.erb`: handle the absence of GNU coreutils on FreeBSD (and potential other platforms)

Besides that I've added `params.pp` to better handle parameters for different operating systems. Furthermore I've added some fixes to make puppet-lint happy.