### PR TITLE
do not create multiple keep-cronjobs

### DIFF
--- a/manifests/periodic.pp
+++ b/manifests/periodic.pp
@@ -56,6 +56,9 @@ define tarsnap::periodic (
   if $keep {
     $off_hour = (24 + ($hour + $offset)) % 24
     cron { "tarsnap-${title}-keep-${keep}":
+      ensure  => absent,
+    }
+    cron { "tarsnap-${title}-keep":
       ensure  => $ensure,
       command => "${::tarsnap::rotate_path} ${title} ${keep}",
       user    => $::tarsnap::user,


### PR DESCRIPTION
Currently, if you use the ` tarsnap::periodic` wrapper...

```puppet
tarsnap::periodic { 'etc':
  dirs => [ '/etc', '/usr/local/etc' ],
  hour => 3,
  keep => 3,
}
```
...two new cronjobs are created, as expected:

```
Notice: /Stage[main]/Tarsnap::Periodic[etc]/Cron[tarsnap-etc-keep-3]/ensure: created
Notice: /Stage[main]/Tarsnap::Periodic[etc]/Cron[tarsnap-etc-create]/ensure: created
```

If you change the value of `keep` from '3' to '4' a new cronjob is created, but the old is not removed:

```
Notice: /Stage[main]/Tarsnap::Periodic[etc]/Cron[tarsnap-etc-keep-4]/ensure: created

# crontab -l 
# Puppet Name: tarsnap-etc-keep-3
5 4 * * * /usr/local/bin/tarsnap-rotate etc 3
# Puppet Name: tarsnap-etc-create
5 3 * * * /usr/local/bin/tarsnap-archive etc /etc /usr/local/etc
# Puppet Name: tarsnap-etc-keep-4
5 4 * * * /usr/local/bin/tarsnap-rotate etc 4
```

As a result, changing the value of `keep` has not the desired effect, as the old value is still enforced by the not deleted cronjob.

I suggest to rename the cronjob in a way that the `keep` parameter it no longer used to construct the name of the cronjob. My patch makes sure to remove the old cronjob for the current configuration and creates a new one.

As a sidenote, this is not an issue if Puppet is configured to purge unmanaged cronjobs. On the otherhand, this feature wasn't introduced until Puppet 3.5.0 and purging unmanaged cronjobs is not always desired.