### PR TITLE
do not try to use undef as meaningful value

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -132,7 +132,7 @@ tarsnap::periodic { 'etc':
 * `name`: base-name of this archive
 * `ensure`: Ensure presence or absence of cron jobs. (Default: `present`)
 * `dirs`: Array of dirs to backup (Default: `[]`)
-* `keep`: How many archives to keep. If this is set to `undef` no archives will be deleted. (Default: `30`)
+* `keep`: How many archives to keep. If this is set to `0` no archives will be deleted. (Default: `30`)
 * `hour`: Hour when to run. (Default: `fqdn_rand(24, $title)`, i.e.: between 00:xx and 23:xx)
 * `minute`: Minute when to run. (Default: `fqdn_rand(60, $title)`, i.e.: between xx:00 and xx:59)
 * `offset`: Offset (in hours) when to run the cleanup job. (Default: `1`)

--- a/manifests/periodic.pp
+++ b/manifests/periodic.pp
@@ -14,7 +14,7 @@
 #   Array of dirs to backup (Default: `[]`)
 #
 # [*keep*]
-#   How many archives to keep. If this is set to `undef` no archives will be
+#   How many archives to keep. If this is set to `0` no archives will be
 #   deleted. (Default: `30`)
 #
 # [*hour*]
@@ -53,7 +53,7 @@ define tarsnap::periodic (
   #   grep for the title,
   #   sort them numerically, then get the everything but last n ($keep)
   #   delete each one of those we've found, separately.
-  if $keep {
+  if $keep > 0 {
     $off_hour = (24 + ($hour + $offset)) % 24
     cron { "tarsnap-${title}-keep-${keep}":
       ensure  => absent,


### PR DESCRIPTION
`undef` is not really a meaningful value, and it can be tricky to set it from hiera.
let's just use `0` for keeping archives forever.