### PR TITLE
class for running archiving (and cleanup) in batch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 group :test do
   gem "rake"
-  gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.7.0'
+  gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.8.0'
   gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem "puppetlabs_spec_helper"
 end

--- a/README.markdown
+++ b/README.markdown
@@ -110,6 +110,21 @@ tarsnap::periodic { 'etc':
 }
 ```
 
+Often if we have a lot of periodic jobs, randomizing will still lead to overlapping runs, which doesn't work with tarnsap. For this purpose we provide a the class `tarsnap::batch`. It can also be directly configured through `tarsnap`:
+
+```puppet
+class { 'tarsnap':
+  locations => {
+    'etc'       => '/etc',
+    'home'      => [ '/home/me/pix', '/home/me/src', '/home/me/txt' ],
+    '.dotfiles' => [ '/home/me/.gnupg', '/home/me/.config', '/home/me/.ssh' ],
+    'blog'      => [ '/home/me/blog/src', '/home/me/blog/pix' ],
+  }
+}
+
+```
+
+
 ## Reference
 
 ### tarsnap
@@ -120,12 +135,14 @@ tarsnap::periodic { 'etc':
 * `path`: Path to tarsnap. (Default: `/usr/bin/tarsnap`)
 * `archive_path`: Path to tarsnap-archive script. (Default: `/usr/local/bin/tarsnap-archive`)
 * `rotate_path`: Path to tarsnap-rotate script. (Default: `/usr/local/bin/tarsnap-rotate`)
+* `batch_path`: Path to tarsnap-batch script. (Default: `/usr/local/bin/tarsnap-batch`)
 * `cachedir`: Path to tarsnap's cachedir. This directory will be created by puppet. (Default: `/var/backups/tarsnap`)
 * `keyfile`: Path to tarsnap's keyfile for this machine. (Default: `/root/tarsnap.key`)
 * `nodump`: Honor the `nodump` file flag. (Default: `true`)
 * `print_stats`: Print statistics when creating or deleting archives. (Default: `true`)
 * `checkpoint_bytes`: Create a checkpoint once per X of uploaded data (Default: `1G`)
 * `aggressive_networking`: Use multiple TCP connections when writing archives. (Default: `undef`)
+* `locations`: Hash of directory arrays to archive in a batch job. (Default: `{}`)
 
 ### tarsnap::periodic
 
@@ -136,6 +153,14 @@ tarsnap::periodic { 'etc':
 * `hour`: Hour when to run. (Default: `fqdn_rand(24, $title)`, i.e.: between 00:xx and 23:xx)
 * `minute`: Minute when to run. (Default: `fqdn_rand(60, $title)`, i.e.: between xx:00 and xx:59)
 * `offset`: Offset (in hours) when to run the cleanup job. (Default: `1`)
+
+### tarsnap::batch
+
+* `ensure`: Ensure presence or absence of batch job. (Default: `present`)
+* `keep`: How many archives to keep. If this is set to `0` no archives will be deleted. (Default: `30`)
+* `hour`: Hour when to run. (Default: `fqdn_rand(6, $title)`, i.e.: between 00:xx and 06:xx)
+* `minute`: Minute when to run. (Default: `fqdn_rand(60, $title)`, i.e.: between xx:00 and xx:59)
+* `locations`: Hash of directory arrays. (Default: `$::tarsnap::locations`)
 
 ## Limitations
 

--- a/manifests/batch.pp
+++ b/manifests/batch.pp
@@ -1,0 +1,28 @@
+# == class tarsnap::batch
+#
+# this class serializes (rather than ineffectually randomize) tarsnap jobs
+#
+class tarsnap::batch (
+  $ensure    = present,
+  $keep      = 30,
+  $hour      = fqdn_rand(6, $title),
+  $minute    = fqdn_rand(60, $title),
+  $locations = $::tarsnap::locations,
+) {
+
+  validate_re($ensure, '^(present|absent)$')
+
+  file { $::tarsnap::batch_path:
+    ensure  => file,
+    mode    => '0755',
+    content => template("${module_name}/tarsnap-batch.erb"),
+  }
+
+  cron { 'tarsnap-batch':
+    ensure  => $ensure,
+    command => $::tarsnap::batch_path,
+    user    => $::tarsnap::user,
+    hour    => $hour,
+    minute  => $minute,
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,9 @@
 # [*rotate_path*]
 #   Path to tarsnap-rotate script. (Default: `/usr/local/bin/tarsnap-rotate`)
 #
+# [*batch_path*]
+#   Path to tarsnap-batch script. (Default: `/usr/local/bin/tarsnap-batch`)
+#
 # [*configfile*]
 #   Path to tarsnap's configuration file. (Default: `/etc/tarsnap.conf`)
 #
@@ -43,12 +46,18 @@
 # [*aggressive_networking*]
 #   Use multiple TCP connections when writing archives. (Default: `undef`)
 #
+# [*batch_enable*]
+#   Whether to include the tarsnap::batch class by default. (Default: false)
+#
+# [*locations*]
+#   Hash, of Hashes, pointing at arrays of directories to archive in a batch job. (Default: {})
 class tarsnap (
   $package_name          = $::tarsnap::params::package_name,
   $package_ensure        = $::tarsnap::params::package_ensure,
   $path                  = $::tarsnap::params::path,
   $archive_path          = $::tarsnap::params::archive_path,
   $rotate_path           = $::tarsnap::params::rotate_path,
+  $batch_path            = $::tarsnap::params::batch_path,
   $configfile            = $::tarsnap::params::configfile,
   $cachedir              = $::tarsnap::params::cachedir,
   $keyfile               = $::tarsnap::params::keyfile,
@@ -58,11 +67,14 @@ class tarsnap (
   $aggressive_networking = $::tarsnap::params::aggressive_networking,
   $user                  = $::tarsnap::params::user,
   $group                 = $::tarsnap::params::group,
+  # batch
+  $locations             = {},
 ) inherits ::tarsnap::params {
 
   validate_absolute_path($path)
   validate_absolute_path($archive_path)
   validate_absolute_path($rotate_path)
+  validate_absolute_path($batch_path)
   validate_absolute_path($configfile)
   validate_absolute_path($cachedir)
   validate_absolute_path($keyfile)
@@ -76,4 +88,8 @@ class tarsnap (
 
   class { '::tarsnap::install': } ~>
   class { '::tarsnap::config': }
+
+  unless empty($locations) {
+    include ::tarsnap::batch
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,6 +18,7 @@ class tarsnap::params {
       $path         = '/usr/bin/tarsnap'
       $archive_path = "${prefix}/bin/tarsnap-archive"
       $rotate_path  = "${prefix}/bin/tarsnap-rotate"
+      $batch_path   = "${prefix}/bin/tarsnap-batch"
       $configfile   = '/etc/tarsnap.conf'
       $cachedir     = '/var/backups/tarsnap'
       $user         = 'root'
@@ -29,6 +30,7 @@ class tarsnap::params {
       $path         = "${prefix}/bin/tarsnap"
       $archive_path = "${prefix}/bin/tarsnap-archive"
       $rotate_path  = "${prefix}/bin/tarsnap-rotate"
+      $batch_path   = "${prefix}/bin/tarsnap-batch"
       $configfile   = "${prefix}/etc/tarsnap.conf"
       $cachedir     = "${prefix}/tarsnap-cache"
       $user         = 'root'

--- a/templates/tarsnap-batch.erb
+++ b/templates/tarsnap-batch.erb
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+date_stamp=$(date +%Y%m%d%H%M)
+# Archive
+<%- @locations.map do |title,paths| -%>
+<%= scope.lookupvar("tarsnap::path") %> --quiet -c -f <%= title -%>.$date_stamp  \
+  <%= Array(paths).join(" \\\n  ") %>
+<%- end -%>
+<%- if @keep > 0 -%>
+
+# Cleanup
+<%-   @locations.keys.each do |title| -%>
+<%= scope.lookupvar("tarsnap::path") %> --list-archives \
+  | grep <%= title -%>. \
+  | sort -rn \
+  | sed '1,<%= @keep -%>d' \
+  | xargs -rn1 <%= scope.lookupvar("tarsnap::path") %> -d -f
+<%-   end -%>
+<%- end -%>

--- a/templates/tarsnap-rotate.erb
+++ b/templates/tarsnap-rotate.erb
@@ -6,15 +6,9 @@ shift
 keep="$1"
 shift
 
-<%- # handle potential absence of GNU coreutils -%>
-<%- if @kernel == "Linux" -%>
-<%-   cmd_keep  = 'tail -n +${keep}' -%>
-<%- else -%>
-<%-   cmd_keep  = 'sed "1,${keep}d"' -%>
-<%- end -%>
 <%= scope.lookupvar("tarsnap::path") %> --list-archives \
   | grep ${title}. \
   | sort -rn \
-  | <%= cmd_keep %> \
+  | sed '1,<%= @keep -%>d' \
   | xargs -rn1 <%= scope.lookupvar("tarsnap::path") %> -d -f
 


### PR DESCRIPTION
tarsnap::batch is a class (not a define) to run all archiving jobs in a
batch rather than randomized through multiple instances of tarsnap::periodic

this addresses #6.