### PR TITLE
Fix a long-standing typo in template lookup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,8 +30,9 @@ Metrics/MethodLength:
 Metrics/ClassLength:
   Enabled: false
 
-# dealbreaker:
-Style/TrailingComma:
+Style/TrailingCommaInArguments:
+  Enabled: false
+Style/TrailingCommaInLiteral:
   Enabled: false
 Style/ClosingParenthesisIndentation:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,26 @@
+#   Copyright 2016 Brainsware
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 ---
-notifications:
-  email: false
-sudo: false
 language: ruby
-cache: bundler
-bundler_args: --without system_tests
-addons:
-  apt:
-    sources:
-      - augeas
-    packages:
-      - libaugeas-dev
+bundler_args: --without development system_tests
+sudo: false
 before_install: rm Gemfile.lock || true
-script:
-  - 'bundle exec rake $CHECK'
+script: bundle exec rake test
 matrix:
-  fast_finish: true
   include:
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 3.4" CHECK=test
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
-  - rvm: 2.1.6
-    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
-  - rvm: 2.1.6
-    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
-  - rvm: 2.2.3
-    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
-  - rvm: 2.2.3
-    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=rubocop
-deploy:
-  provider: puppetforge
-  user: brainsware
-  password:
-    secure: "GpJtOasaHmxgHmA+PZ4w/KdYNIa4//PiO6F2qa58888cfK/7/9rCwZ5mbh+qsChMAy1QbVeDQZGFAgqxcL7Ix4uEf4QeQOpgOwAMPBl7SjctDb23iAAGU/qWmG2+nPAFqUdsA1zQafu89/ou0M/Ye0cJpG0vRb6YhrhhRRXuw3M="
-  on:
-    tags: true
-    # all_branches is required to use tags
-    all_branches: true
-    # Only publish if our main Ruby target builds
-    rvm: 1.9.3
+  - rvm: 2.0.0
+    env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES="yes"
+  - rvm: 2.1.0
+    env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES=yes

--- a/Gemfile
+++ b/Gemfile
@@ -1,28 +1,19 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 group :test do
-  gem 'rake'
-  gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.8.0'
-  gem 'rspec-puppet', git: 'https://github.com/rodjek/rspec-puppet.git'
-  gem 'rspec-puppet-augeas'
-  gem 'ruby-augeas'
-  gem 'puppetlabs_spec_helper'
-  gem 'metadata-json-lint'
-  gem 'rspec-puppet-facts'
-  gem 'rspec'
-  gem 'puppet-blacksmith'
-  gem 'rubocop'
-  gem 'puppet-lint-absolute_classname-check'
-  gem 'puppet-lint-leading_zero-check'
-  gem 'puppet-lint-trailing_comma-check'
-  gem 'puppet-lint-version_comparison-check'
-  gem 'puppet-lint-classes_and_types_beginning_with_digits-check'
-  gem 'puppet-lint-unquoted_string-check'
-  gem 'puppet-lint-variable_contains_upcase'
+  gem "rake"
+  gem "puppet", ENV['PUPPET_VERSION'] || '~> 4.8.0'
+  gem "rspec-puppet", '~> 2.5'
+  gem "puppetlabs_spec_helper", '~> 1.2.2'
+  gem "metadata-json-lint"
+  gem "rspec-puppet-facts"
+  gem "rspec"
+  gem "rubocop"
+  gem "puppet-blacksmith"
 end
 
 group :development do
-  gem 'travis'
-  gem 'travis-lint'
-  gem 'guard-rake'
+  gem "travis"
+  gem "travis-lint"
+  gem "guard-rake"
 end

--- a/spec/classes/tarsnap_spec.rb
+++ b/spec/classes/tarsnap_spec.rb
@@ -27,6 +27,7 @@ describe 'tarsnap', :type => :class do
             owner:  'root',
             group:  group,
           )
+          is_expected.to contain_file("#{sysconf}/tarsnap.conf").with_content(/^#aggressive-networking/)
         end
         it do
           is_expected.to contain_file(cachedir).with(

--- a/spec/defines/periodic_spec.rb
+++ b/spec/defines/periodic_spec.rb
@@ -14,7 +14,7 @@ describe 'tarsnap::periodic', :type => :define do
         let(:params) do
           {
             'ensure' => 'present',
-            'dirs'   => %w( /etc /opt/etc /usr/local/etc ),
+            'dirs'   => %w(/etc /opt/etc /usr/local/etc),
           }
         end
 

--- a/templates/tarsnap.conf.erb
+++ b/templates/tarsnap.conf.erb
@@ -21,7 +21,7 @@ checkpoint-bytes <%= scope.lookupvar("tarsnap::checkpoint_bytes") %>
 # writing archives.  Use of this option is recommended only in
 # cases where TCP congestion control is known to be the limiting
 # factor in upload performance.
-<%- if scope.lookupvar("tarsnap::aggresssive_networking").nil? -%>
+<%- if scope.lookupvar("tarsnap::aggressive_networking").nil? -%>
 #aggressive-networking
 <%- elsif !scope.lookupvar("tarsnap::aggressive_networking") -%>
 no-aggressive-networking


### PR DESCRIPTION
tarsnap::aggresssive_networking → tarsnap::aggressive_networking.

in order to fix this, I had to do a small yak-shave around rubocop.