### PR TITLE
Utilize Stdlib vs Tea for Absolutepath lookups

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,5 @@
 fixtures:
   repositories:
     stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    tea:    "git://github.com/voxpupuli/puppet-tea.git"
   symlinks:
     tarsnap: "#{source_dir}"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,3 +56,10 @@ Style/ClassAndModuleChildren:
 Style/Documentation:
   Description: 'Document classes and non-namespace modules.'
   Enabled: false
+
+Style/FileName:
+  Enabled: true
+  Exclude:
+    - Rakefile
+    - Gemfile
+    - Guardfile

--- a/Gemfile
+++ b/Gemfile
@@ -1,38 +1,50 @@
-source ENV['GEM_SOURCE'] || "https://rubygems.org"
+gem_source = if ENV['GEM_SOURCE'].nil?
+               'http://rubygems.org'
+             else
+               ENV['GEM_SOURCE']
+             end
+
+source gem_source
 
 group :test do
-  gem 'puppetlabs_spec_helper', '~> 1.2.2',                         :require => false
-  gem 'rspec-puppet',                                               :require => false, :git => 'https://github.com/rodjek/rspec-puppet.git'
-  gem 'rspec-puppet-facts',                                         :require => false
-  gem 'rspec-puppet-utils',                                         :require => false
-  gem 'puppet-lint-absolute_classname-check',                       :require => false
-  gem 'puppet-lint-leading_zero-check',                             :require => false
-  gem 'puppet-lint-trailing_comma-check',                           :require => false
-  gem 'puppet-lint-version_comparison-check',                       :require => false
-  gem 'puppet-lint-classes_and_types_beginning_with_digits-check',  :require => false
-  gem 'puppet-lint-unquoted_string-check',                          :require => false
-  gem 'puppet-lint-variable_contains_upcase',                       :require => false
   gem 'metadata-json-lint',                                         :require => false
   gem 'puppet-blacksmith',                                          :require => false
-  gem 'voxpupuli-release',                                          :require => false, :git => 'https://github.com/voxpupuli/voxpupuli-release-gem.git'
+  gem 'puppet-lint-absolute_classname-check',                       :require => false
+  gem 'puppet-lint-classes_and_types_beginning_with_digits-check',  :require => false
+  gem 'puppet-lint-leading_zero-check',                             :require => false
+  gem 'puppet-lint-trailing_comma-check',                           :require => false
+  gem 'puppet-lint-unquoted_string-check',                          :require => false
+  gem 'puppet-lint-variable_contains_upcase',                       :require => false
+  gem 'puppet-lint-version_comparison-check',                       :require => false
   gem 'puppet-strings', '~> 1.0.0',                                 :require => false
+  gem 'puppetlabs_spec_helper', '~> 1.2.2',                         :require => false
+  gem 'rspec-puppet',                                               :require => false, :git => 'http://github.com/rodjek/rspec-puppet.git'
+  gem 'rspec-puppet-facts',                                         :require => false
+  gem 'rspec-puppet-utils',                                         :require => false
   gem 'rubocop-rspec', '~> 1.6',                                    :require => false if RUBY_VERSION >= '2.3.0'
+  gem 'voxpupuli-release',                                          :require => false, :git => 'http://github.com/voxpupuli/voxpupuli-release-gem.git'
 end
 
 group :development do
+  gem 'guard-rake',   :require => false
   gem 'travis',       :require => false
   gem 'travis-lint',  :require => false
-  gem 'guard-rake',   :require => false
 end
 
+facterversion = if ENV['FACTER_GEM_VERSION'].nil?
+                  '~> 2.5'
+                else
+                  ENV['FACTER_GEM_VERSION']
+                end
 
-if facterversion = ENV['FACTER_GEM_VERSION']
-  gem 'facter', facterversion.to_s, :require => false, :groups => [:test]
-else
-  gem 'facter', :require => false, :groups => [:test]
-end
+gem 'facter', facterversion.to_s, :require => false, :groups => [:test]
 
-ENV['PUPPET_VERSION'].nil? ? puppetversion = '~> 4.0' : puppetversion = ENV['PUPPET_VERSION'].to_s
+puppetversion = if ENV['PUPPET_VERSION'].nil?
+                  '~> 4.0'
+                else
+                  ENV['PUPPET_VERSION'].to_s
+                end
+
 gem 'puppet', puppetversion, :require => false, :groups => [:test]
 
 # vim: syntax=ruby

--- a/Rakefile
+++ b/Rakefile
@@ -6,12 +6,12 @@ require 'puppet_blacksmith/rake_tasks'
 require 'puppet-strings/tasks'
 
 if RUBY_VERSION >= '2.3.0'
-  require 'rubocop/rake_task'
+  require 'rubocop/rake_task.rb'
   RuboCop::RakeTask.new
 end
 
 PuppetLint.configuration.relative = true
-PuppetLint.configuration.log_format = '%{path}:%{linenumber}:%{check}:%{KIND}:%{message}'
+PuppetLint.configuration.log_format = '%<path>s:%<linenumber>s:%<check>s:%<KIND>s:%<message>s'
 PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.send('disable_relative_classname_inclusion')
 
@@ -21,11 +21,11 @@ PuppetLint.configuration.send('disable_class_parameter_defaults')
 # http://puppet-lint.com/checks/class_inherits_from_params_class/
 PuppetLint.configuration.send('disable_class_inherits_from_params_class')
 
-exclude_paths = %w(
-  pkg/**/*
-  vendor/**/*
-  spec/**/*
-)
+exclude_paths = [
+  'pkg/**/*',
+  'vendor/**/*',
+  'spec/**/*',
+]
 PuppetLint.configuration.ignore_paths = exclude_paths
 PuppetSyntax.exclude_paths = exclude_paths
 
@@ -35,11 +35,11 @@ RSpec::Core::RakeTask.new(:acceptance) do |t|
 end
 
 desc 'Run metadata_lint, lint, syntax, and spec tests.'
-task test: [
-  :metadata_lint,
-  :lint,
-  :syntax,
-  :spec,
+task test: %I[
+  metadata_lint
+  lint
+  syntax
+  spec
 ]
 
 Blacksmith::RakeTask.new do |t|
@@ -56,7 +56,7 @@ task travis_release: [
 desc 'Check Changelog.'
 task :check_changelog do
   v = Blacksmith::Modulefile.new.version
-  if File.readlines('CHANGELOG.md').grep(/Releasing v#{v}/).size == 0
-    fail "Unable to find a CHANGELOG.md entry for the #{v} release."
+  if File.readlines('CHANGELOG.md').grep(/Releasing v#{v}/).size.zero?
+    raise "Unable to find a CHANGELOG.md entry for the #{v} release."
   end
 end

--- a/manifests/batch.pp
+++ b/manifests/batch.pp
@@ -8,6 +8,8 @@ class tarsnap::batch (
           $hour      = fqdn_rand(6, $title),
           $minute    = fqdn_rand(60, $title),
   Optional[Tarsnap::Location] $locations = $tarsnap::locations,
+  String $batch_path = '/usr/local/bin/tarsnap-batch',
+  String $user       = 'root',
 ) {
 
   $ensure = $enable ? {
@@ -15,7 +17,7 @@ class tarsnap::batch (
     default => 'present',
   }
 
-  file { $tarsnap::batch_path:
+  file { $batch_path:
     ensure  => $ensure,
     mode    => '0755',
     content => epp("${module_name}/tarsnap-batch.epp"),
@@ -23,8 +25,8 @@ class tarsnap::batch (
 
   cron { 'tarsnap-batch':
     ensure  => $ensure,
-    command => $tarsnap::batch_path,
-    user    => $tarsnap::user,
+    command => $batch_path,
+    user    => $user,
     hour    => $hour,
     minute  => $minute,
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,8 +31,13 @@ class tarsnap (
 
   Class[tarsnap::install] ~> Class[tarsnap::config]
 
-  class { 'tarsnap::batch':
-    enable    => $batch_enable,
-    locations => $locations,
+  if $batch_enable {
+    class { 'tarsnap::batch':
+      enable     => $batch_enable,
+      locations  => $locations,
+      batch_path => $batch_path,
+      user       => $user,
+      path       => $path,
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,16 +6,16 @@
 #
 class tarsnap (
   String $package_name,
-  Tea::Absolutepath $path,
-  Tea::Absolutepath $archive_path,
-  Tea::Absolutepath $rotate_path,
-  Tea::Absolutepath $batch_path,
-  Tea::Absolutepath $configfile,
-  Tea::Absolutepath $cachedir,
+  Stdlib::Absolutepath $path,
+  Stdlib::Absolutepath $archive_path,
+  Stdlib::Absolutepath $rotate_path,
+  Stdlib::Absolutepath $batch_path,
+  Stdlib::Absolutepath $configfile,
+  Stdlib::Absolutepath $cachedir,
   String $user,
   String $group,
   String $package_ensure        = 'present',
-  Tea::Absolutepath $keyfile    = '/root/tarsnap.key',
+  Stdlib::Absolutepath $keyfile    = '/root/tarsnap.key',
   # config
   Boolean           $nodump                = true,
   Boolean           $print_stats           = true,

--- a/manifests/periodic.pp
+++ b/manifests/periodic.pp
@@ -3,9 +3,9 @@
 # wrapper around cron to create and (optionally) cleanup tarsnap archives
 #
 define tarsnap::periodic (
-  Array[Tea::Absolutepath] $dirs,
+  Array[Stdlib::Absolutepath] $dirs,
   Enum[present, absent]    $ensure  = present,
-  Array[Tea::Absolutepath] $exclude = [],
+  Array[Stdlib::Absolutepath] $exclude = [],
   # won't validate these, since they are passed directly to cron
   $keep     = 30,
   $hour     = fqdn_rand(24, $title),

--- a/metadata.json
+++ b/metadata.json
@@ -12,10 +12,6 @@
     {
       "name": "puppetlabs-stdlib",
       "version_requirement": ">= 4.0.0 <= 5.0.0"
-    },
-    {
-      "name": "puppet-tea",
-      "version_requirement": ">= 0.2.0 <= 2.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/tarsnap_spec.rb
+++ b/spec/classes/tarsnap_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper.rb'
 
-describe 'tarsnap setup', :type => :class do
+describe 'tarsnap', :type => :class do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
@@ -27,7 +27,7 @@ describe 'tarsnap setup', :type => :class do
     end
   end
 end
-describe 'tarsnap batch', :type => :class do
+describe 'tarsnap::batch', :type => :class do
   context 'creating a batch process' do
     _os, facts = on_supported_os.first
     let(:facts) do
@@ -36,8 +36,8 @@ describe 'tarsnap batch', :type => :class do
 
     let(:params) do
       {
-        :batch_enable => true,
-        :locations    => {
+        :enable => true,
+        :locations => {
           'etc'      => ['/etc/', '/usr/local/etc', '/opt/etc'],
           'home'     => ['/home/me/src', '/home/me/pix'],
           'dotfiles' => ['/home/me/.ssh', '/home/me/.config'],

--- a/spec/classes/tarsnap_spec.rb
+++ b/spec/classes/tarsnap_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper.rb'
 
-describe 'tarsnap', :type => :class do
+describe 'tarsnap setup', :type => :class do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
@@ -20,27 +20,14 @@ describe 'tarsnap', :type => :class do
           group    = 'root'
         end
 
-        it do
-          is_expected.to contain_file("#{sysconf}/tarsnap.conf").with(
-            ensure: 'file',
-            mode:   '0644',
-            owner:  'root',
-            group:  group,
-          )
-          is_expected.to contain_file("#{sysconf}/tarsnap.conf").with_content(/^#aggressive-networking/)
-        end
-        it do
-          is_expected.to contain_file(cachedir).with(
-            ensure: 'directory',
-            mode:   '0700',
-            owner:  'root',
-            group:  group,
-          )
-        end
+        it { is_expected.to contain_file("#{sysconf}/tarsnap.conf").with(ensure: 'file', mode: '0644', owner: 'root', group: group).with_content(/^#aggressive-networking/) }
+
+        it { is_expected.to contain_file(cachedir).with(ensure: 'directory', mode: '0700', owner: 'root', group: group) }
       end
     end
   end
-
+end
+describe 'tarsnap batch', :type => :class do
   context 'creating a batch process' do
     _os, facts = on_supported_os.first
     let(:facts) do
@@ -58,13 +45,7 @@ describe 'tarsnap', :type => :class do
       }
     end
     it do
-      is_expected.to contain_file('/usr/local/bin/tarsnap-batch').with(
-        'ensure' => 'present',
-        'mode'   => '0755',
-      )
-    end
-    it do
-      is_expected.to contain_file('/usr/local/bin/tarsnap-batch').with_content(
+      is_expected.to contain_file('/usr/local/bin/tarsnap-batch').with('ensure' => 'present', 'mode' => '0755').with_content(
         %r{.* /usr/local/etc \\\n.*}
       )
     end

--- a/spec/defines/periodic_spec.rb
+++ b/spec/defines/periodic_spec.rb
@@ -14,7 +14,7 @@ describe 'tarsnap::periodic', :type => :define do
         let(:params) do
           {
             'ensure' => 'present',
-            'dirs'   => %w(/etc /opt/etc /usr/local/etc),
+            'dirs'   => ['/etc /opt/etc /usr/local/etc'],
           }
         end
 

--- a/templates/tarsnap-batch.epp
+++ b/templates/tarsnap-batch.epp
@@ -3,17 +3,17 @@
 date_stamp=$(date +%Y%m%d%H%M)
 # Archive
 <%- $tarsnap::batch::locations.map |$title, $paths| { -%>
-<%= $tarsnap::path %> --quiet -c -f <%= $title -%>.$date_stamp  \
+<%= $tarsnap::batch::path %> --quiet -c -f <%= $title -%>.$date_stamp  \
   <%= [$paths].join(" \\\n  ") %>
 <%- } -%>
 <%- if $tarsnap::batch::keep > 0 {-%>
 
 # Cleanup
 <%-   $tarsnap::batch::locations.keys.each |$title| { -%>
-<%= $tarsnap::path %> --list-archives \
+<%= $tarsnap::batch::path %> --list-archives \
   | grep <%= $title -%>. \
   | sort -rn \
   | sed '1,<%= $tarsnap::batch::keep -%>d' \
-  | xargs -rn1 <%= $tarsnap::path %> -d -f
+  | xargs -rn1 <%= $tarsnap::batch::path %> -d -f
 <%-   } -%>
 <%- } -%>

--- a/types/location.pp
+++ b/types/location.pp
@@ -1,1 +1,1 @@
-type Tarsnap::Location = Hash[String, Variant[Tea::Absolutepath, Array[Tea::Absolutepath]]]
+type Tarsnap::Location = Hash[String, Variant[Stdlib::Absolutepath, Array[Stdlib::Absolutepath]]]


### PR DESCRIPTION
`stdlib` includes 'Absolutepath' as of tag '4.13.0' - this PR updates the required manifest files with the updated resource type. 